### PR TITLE
PFDR-230 - Remove proxy setting; add env config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+REACT_APP_API_URL=/
+REACT_APP_REPO_NAME=Digital Repository

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+REACT_APP_API_URL=http://localhost:3000/
+REACT_APP_REPO_NAME=Development Repository

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Configuration
+
+There are two environment variables that can be set to ensure that the app
+has correct labeling and can issue requests to the API:
+
+ * `REACT_APP_API_URL`: the URL of the API; must include the protocol; defaults 
+   to http://localhost:3000/ in development
+ * `REACT_APP_REPO_NAME`: the title of the repository, to be displayed prominently
+   in the interfact
+
+The defaults are set in `.env` and `.env.development`. You can use `*.local` for
+overrides that will be ignored by Git. There are details of how this works in the
+[upstream documentation](https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables).
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "chipmunk-frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy:": "http://localhost:3000",
   "dependencies": {
     "@umich-lib/core": "1.0.0-beta.3",
     "react": "^16.8.6",

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,9 @@ import ArtifactSearch from "./artifact_search";
 import ArtifactView from "./artifact_view";
 import errorMessage from "./error_message";
 
+const API_URL = process.env.REACT_APP_API_URL;
+const REPO_NAME = process.env.REACT_APP_REPO_NAME;
+
 function App() {
   return (
     <div>
@@ -19,7 +22,7 @@ function App() {
           <Heading level={1} size="3XL" style={{
             marginTop: SPACING['2XL'],
             marginBottom: SPACING['XL']
-          }}>Catalogued and Hosted Electronic Resources</Heading>
+          }}>{REPO_NAME}</Heading>
           <BrowserRouter>
             <Route path="/" exact component={SearchWrapper}/>
             <Route path="/artifacts/:id" component={DirectArtifact}/>
@@ -32,7 +35,7 @@ function App() {
 
 function SearchWrapper() {
   return (
-    <ArtifactSearch api="/"/>
+    <ArtifactSearch api={API_URL} />
   );
 }
 
@@ -53,7 +56,7 @@ class ErroringArtifact extends React.Component {
   render() {
     return (
       <ArtifactView
-        api="/"
+        api={API_URL}
         id={this.props.id}
         onError={e => { this.setError(e) }}
         error={this.state.error}


### PR DESCRIPTION
The proxy setting was flaky, and we need to be able to supply other
config values, so this introduces a couple of environment variables.
They are not handled in a structured way here -- just a couple of top
level constants -- but they introduce the mechanism.

The variables are:

 * REACT_APP_API_URL -> API_URL: the url of the running API
 * REACT_APP_REPO_NAME -> REPO_NAME: the name of the repository, to be
   used as the main title in the UI